### PR TITLE
remove trailing slash from default theme directory

### DIFF
--- a/content/mu-plugins/index.php
+++ b/content/mu-plugins/index.php
@@ -1,2 +1,2 @@
 <?php
-register_theme_directory( ABSPATH . 'wp-content/themes/' );
+register_theme_directory( ABSPATH . 'wp-content/themes' );


### PR DESCRIPTION
The trailing slash caused a double slash when using default themes from wordpress/wp-content/themes
